### PR TITLE
Add /scripts VOLUME to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,6 @@ ADD . /opt/src/pymssql/
 
 RUN pip install /opt/src/pymssql
 
+VOLUME ["/scripts"]
+
 CMD ["ipython"]


### PR DESCRIPTION
Add /scripts VOLUME to Dockerfile so that python code doesn't need to be inside the container.
